### PR TITLE
Builder.io: Transform app to portfolio site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "haitani",
+  "name": "portofolio-react",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "haitani",
+      "name": "portofolio-react",
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,342 @@
-#root {
-  max-width: 1280px;
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap");
+
+/* Reset and base styles */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family:
+    "Inter",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  background-color: #ffffff;
+  color: #333;
+  line-height: 1.6;
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+/* Navigation Styles */
+.navigation {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  z-index: 1000;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.navigation-container {
+  max-width: 1440px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 24px 108px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.brand h1 {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 2px;
+  color: #333;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.nav-links {
+  display: flex;
+  list-style: none;
+  gap: 48px;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: #666;
+  font-weight: 400;
+  font-size: 16px;
+  transition: color 0.3s ease;
+}
+
+.nav-links a:hover {
+  color: #333;
+}
+
+/* Main Content */
+.main-content {
+  flex: 1;
+  padding-top: 96px; /* Account for fixed navigation */
+}
+
+/* Hero Section */
+.hero-section {
+  padding: 126px 0 80px;
+}
+
+.hero-container {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 0 108px;
+  display: grid;
+  grid-template-columns: 1fr 600px;
+  gap: 80px;
+  align-items: center;
+}
+
+.hero-content {
+  max-width: 544px;
+}
+
+.hero-description {
+  font-size: 24px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #666;
+  margin-bottom: 48px;
+}
+
+.hero-actions {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+}
+
+.contact-button {
+  background-color: #c8ff00;
+  border: none;
+  padding: 16px 32px;
+  border-radius: 8px;
+  font-family: "Inter", sans-serif;
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 1px;
+  color: #333;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: all 0.3s ease;
+}
+
+.contact-button:hover {
+  background-color: #b3e600;
+  transform: translateY(-2px);
+}
+
+.contact-arrow {
+  font-size: 16px;
+  transition: transform 0.3s ease;
+}
+
+.contact-button:hover .contact-arrow {
+  transform: translateX(4px);
+}
+
+.social-links {
+  display: flex;
+  gap: 16px;
+}
+
+.social-link {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background-color: #333;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+.social-link:hover {
+  background-color: #555;
+  transform: translateY(-2px);
+}
+
+.social-link.linkedin:hover {
+  background-color: #0077b5;
+}
+
+.social-link.github:hover {
+  background-color: #333;
+}
+
+/* Hero Image */
+.hero-image {
+  width: 600px;
+  height: 700px;
+  position: relative;
+}
+
+.profile-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+}
+
+/* Bottom Line */
+.bottom-line {
+  height: 1px;
+  background-color: #e5e5e5;
+  width: 100%;
+}
+
+/* Tablet Styles */
+@media (max-width: 1200px) {
+  .navigation-container,
+  .hero-container {
+    padding-left: 64px;
+    padding-right: 64px;
   }
-  to {
-    transform: rotate(360deg);
+
+  .hero-container {
+    grid-template-columns: 1fr 500px;
+    gap: 64px;
+  }
+
+  .hero-image {
+    width: 500px;
+    height: 600px;
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+@media (max-width: 1024px) {
+  .navigation-container,
+  .hero-container {
+    padding-left: 32px;
+    padding-right: 32px;
+  }
+
+  .hero-container {
+    grid-template-columns: 1fr;
+    gap: 48px;
+    text-align: center;
+  }
+
+  .hero-content {
+    max-width: 100%;
+    order: 2;
+  }
+
+  .hero-image {
+    width: 400px;
+    height: 500px;
+    margin: 0 auto;
+    order: 1;
+  }
+
+  .hero-section {
+    padding: 80px 0 60px;
   }
 }
 
-.card {
-  padding: 2em;
+/* Mobile Styles */
+@media (max-width: 768px) {
+  .navigation-container {
+    padding: 20px 24px;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .brand h1 {
+    font-size: 16px;
+  }
+
+  .nav-links {
+    gap: 32px;
+  }
+
+  .nav-links a {
+    font-size: 14px;
+  }
+
+  .main-content {
+    padding-top: 120px; /* Increased for stacked mobile nav */
+  }
+
+  .hero-container {
+    padding: 0 24px;
+    gap: 32px;
+  }
+
+  .hero-section {
+    padding: 60px 0 40px;
+  }
+
+  .hero-description {
+    font-size: 20px;
+    margin-bottom: 32px;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+  }
+
+  .hero-image {
+    width: 300px;
+    height: 375px;
+  }
+
+  .contact-button {
+    padding: 14px 28px;
+    font-size: 13px;
+  }
 }
 
-.read-the-docs {
-  color: #888;
+@media (max-width: 480px) {
+  .navigation-container {
+    padding: 16px 20px;
+  }
+
+  .nav-links {
+    gap: 24px;
+  }
+
+  .hero-container {
+    padding: 0 20px;
+  }
+
+  .hero-description {
+    font-size: 18px;
+  }
+
+  .hero-image {
+    width: 280px;
+    height: 350px;
+  }
+
+  .brand h1 {
+    font-size: 14px;
+    letter-spacing: 1px;
+  }
+}
+
+/* Smooth scrolling */
+html {
+  scroll-behavior: smooth;
+}
+
+/* Focus styles for accessibility */
+.contact-button:focus,
+.nav-links a:focus,
+.social-link:focus {
+  outline: 2px solid #c8ff00;
+  outline-offset: 2px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -15,8 +15,8 @@ body {
     "Segoe UI",
     Roboto,
     sans-serif;
-  background-color: #ffffff;
-  color: #333;
+  background-color: #0a0a0a;
+  color: #ffffff;
   line-height: 1.6;
 }
 
@@ -33,10 +33,10 @@ body {
   top: 0;
   left: 0;
   right: 0;
-  background-color: rgba(255, 255, 255, 0.95);
+  background-color: rgba(10, 10, 10, 0.95);
   backdrop-filter: blur(10px);
   z-index: 1000;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .navigation-container {
@@ -52,7 +52,7 @@ body {
   font-size: 18px;
   font-weight: 600;
   letter-spacing: 2px;
-  color: #333;
+  color: #ffffff;
 }
 
 .nav-links {
@@ -63,14 +63,14 @@ body {
 
 .nav-links a {
   text-decoration: none;
-  color: #666;
+  color: #cccccc;
   font-weight: 400;
   font-size: 16px;
   transition: color 0.3s ease;
 }
 
 .nav-links a:hover {
-  color: #333;
+  color: #ffffff;
 }
 
 /* Main Content */
@@ -102,7 +102,7 @@ body {
   font-size: 24px;
   font-weight: 400;
   line-height: 1.5;
-  color: #666;
+  color: #cccccc;
   margin-bottom: 48px;
 }
 
@@ -121,7 +121,7 @@ body {
   font-weight: 600;
   font-size: 14px;
   letter-spacing: 1px;
-  color: #333;
+  color: #0a0a0a;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -152,8 +152,8 @@ body {
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  background-color: #333;
-  color: white;
+  background-color: #ffffff;
+  color: #0a0a0a;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -162,16 +162,18 @@ body {
 }
 
 .social-link:hover {
-  background-color: #555;
+  background-color: #e5e5e5;
   transform: translateY(-2px);
 }
 
 .social-link.linkedin:hover {
   background-color: #0077b5;
+  color: #ffffff;
 }
 
 .social-link.github:hover {
   background-color: #333;
+  color: #ffffff;
 }
 
 /* Hero Image */
@@ -192,7 +194,7 @@ body {
 /* Bottom Line */
 .bottom-line {
   height: 1px;
-  background-color: #e5e5e5;
+  background-color: #333333;
   width: 100%;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,17 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import React from "react";
+import { Navigation, HeroSection } from "./components";
+import "./App.css";
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <div className="app">
+      <Navigation />
+      <main className="main-content">
+        <HeroSection />
+      </main>
+      <div className="bottom-line"></div>
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+
+const HeroSection: React.FC = () => {
+  return (
+    <section className="hero-section">
+      <div className="hero-container">
+        <div className="hero-content">
+          <div className="hero-text">
+            <p className="hero-description">
+              A Sydney based front-end developer passionate about building
+              accessible and user friendly websites
+            </p>
+            <div className="hero-actions">
+              <button className="contact-button">
+                CONTACT ME
+                <span className="contact-arrow">→</span>
+              </button>
+              <div className="social-links">
+                <a
+                  href="#"
+                  className="social-link linkedin"
+                  aria-label="LinkedIn"
+                >
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                  </svg>
+                </a>
+                <a href="#" className="social-link github" aria-label="GitHub">
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                  </svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="hero-image">
+          <img
+            src="https://cdn.builder.io/api/v1/image/assets%2Fae6731d095ca4a9894e3fcb0d9831f55%2F0083294c902847f9bf0acfdf02db43cf?format=webp&width=800"
+            alt="Robert Garcia - Front-end Developer"
+            className="profile-image"
+          />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HeroSection;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+interface NavigationProps {
+  className?: string;
+}
+
+const Navigation: React.FC<NavigationProps> = ({ className = "" }) => {
+  return (
+    <nav className={`navigation ${className}`}>
+      <div className="navigation-container">
+        <div className="brand">
+          <h1>ROBERT GARCIA</h1>
+        </div>
+        <ul className="nav-links">
+          <li>
+            <a href="#work">Work</a>
+          </li>
+          <li>
+            <a href="#about">About</a>
+          </li>
+          <li>
+            <a href="#contact">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  );
+};
+
+export default Navigation;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,2 @@
+export { default as Navigation } from "./Navigation";
+export { default as HeroSection } from "./HeroSection";


### PR DESCRIPTION
This pull request transforms the default React application into a portfolio website.

Changes made:
- Renamed project from "haitani" to "portofolio-react" in package-lock.json
- Completely rewrote App.css with new portfolio styling including navigation, hero section, responsive design, and dark theme
- Replaced default App.tsx content with new portfolio layout using Navigation and HeroSection components
- Added new Navigation.tsx component with brand name "ROBERT GARCIA" and navigation links
- Added new HeroSection.tsx component featuring developer description, contact button, social links, and profile image
- Created components/index.ts for component exports

The new design features a dark theme, fixed navigation, hero section with profile image, and responsive layout for mobile and tablet devices.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b7c0c277a2404488a349151a2921fe8b/curry-works)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b7c0c277a2404488a349151a2921fe8b</projectId>-->
<!--<branchName>curry-works</branchName>-->